### PR TITLE
Fix WebMention avatar css

### DIFF
--- a/components/WebMentions/WebMentionItem.js
+++ b/components/WebMentions/WebMentionItem.js
@@ -21,7 +21,7 @@ const handleLineBreaks = (text: string) =>
 
 export default ({ mention }: { mention: WebMention }) => (
   <Flex flexDirection="row" my={3}>
-    <Box width={40} mr={3}>
+    <Box width={40} mr={3} flex="0 0 auto">
       <Link href={mention.url}>
         <Image
           width={40}


### PR DESCRIPTION
Some avatars where getting squished, this fixes it (:

Really nice, first time hearing about `webmention.io`.

| ![Screen Shot 2019-04-22 at 00 30 07](https://user-images.githubusercontent.com/8649362/56481788-211e8b80-6497-11e9-835e-651a9eab3b14.png) | ![Screen Shot 2019-04-22 at 00 29 43](https://user-images.githubusercontent.com/8649362/56481809-3e535a00-6497-11e9-9b48-fece8baf6970.png) |
|:---:|:---:|
| `before` | `after` |