### PR TITLE
Add an abbrevation to usage of word BFF

### DIFF
--- a/src/pages/thoughts/graphql.md
+++ b/src/pages/thoughts/graphql.md
@@ -56,7 +56,7 @@ On top of that, you can monitor which clients are using which fields because the
 
 #### 2. Slow loading times because of request waterfalls and/or overfetching
 
-With GraphQL, a client sends one request for all the data it needs to render the whole page/view, and the server resolves all of it and sends it back in one response—without the duplication introduced by BFFs. (the client can even ask the server to stream above-the-fold data first with the `@defer` and `@stream` directives)
+With GraphQL, a client sends one request for all the data it needs to render the whole page/view, and the server resolves all of it and sends it back in one response—without the duplication introduced by <abbr title="Backend for Frontend">BFF</abbr>s. (the client can even ask the server to stream above-the-fold data first with the `@defer` and `@stream` directives)
 
 #### 3. Difficult maintenance and endpoint discovery due to hundreds of duplicative one-off endpoints
 


### PR DESCRIPTION
Hi there! https://mxstbr.com/thoughts/graphql/ is a great post, thanks for that!

I had to google the term "BFF" as I hadn't heard it used in programming context earlier so I figured maybe adding a [`<abbr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr) around that would be useful?

I checked that it would seem to work out of the box without any styling changes — at least, doing this change in inspector would give a result like this:

<img width="581" alt="image" src="https://github.com/mxstbr/mxstbr.com/assets/482561/fa397290-96a8-410a-9a0a-728c13add3c3">

There's another usage of the term `BFF` later but this was the first usage so I figured I'd send the smallest possible change request first.