### PR TITLE
Update page.tsx

### DIFF
--- a/app/oss/page.tsx
+++ b/app/oss/page.tsx
@@ -95,7 +95,7 @@ function Repo({ repo }) {
         <p className="text-slate-900 dark:text-slate-100 ">
           <a
             className="underline"
-            href={`https://github.com${repo.nameWithOwner}`}
+            href={`https://github.com/${repo.nameWithOwner}`}
           >
             {repo.nameWithOwner}
           </a>


### PR DESCRIPTION
This commit fixes missing trailing slash after `github.com` domain on the oss links in page.tsx

Hey @mxstbr, came across your blog today at random, really inspiring and awesome stuff! I truly appreciate how much you have given to the open source community, I use lots of your projects and am very grateful for your contributions.

I noticed your page on oss stuff seem to have broken links, e.g. "https://github.comstyled-components/styled-components" instead of "https://github.com/styled-components/styled-components" (missing a '/' after github.com)

I'm assuming the issue stems from this part in the code I found looking at your website source out of curiosity so decided to push a patch for you.

Apologies in advance in case I'm overstepping and you don't accept contributions on your personal blog page, feel free to decline my PR and adjust how you prefer.

Have a great Sunday, cheers from Canada! 👋 😁